### PR TITLE
[feat] 회원가입 유효성 검사 추가

### DIFF
--- a/Member/src/main/java/click/bitbank/api/infrastructure/exception/status/ExceptionMessage.java
+++ b/Member/src/main/java/click/bitbank/api/infrastructure/exception/status/ExceptionMessage.java
@@ -21,7 +21,12 @@ public enum ExceptionMessage {
 
     SaveFailMember("RegistrationFailException", "회원 가입에 실패했습니다. 관리자에게 문의 바랍니다."),
     
-    NotFoundMember("NotFoundDataException", "조회된 회원 정보가 없습니다.");
+    NotFoundMember("NotFoundDataException", "조회된 회원 정보가 없습니다."),
+
+    IsRequiredAlphaNumericForMemberLoginId("BadRequestException", "아이디를 문자 혹은 숫자로 입력하세요"),
+    IsRequiredAlphaForMemberName("BadRequestException", "이름을 문자로 입력하세요"),
+    IsRequiredStringLengthForMemberLoginId("BadRequestException", "8자 이상의 아이디를 입력하세요"),
+    IsRequiredCharNumberSpecialCharactersForMemberPassword("BadRequestException", "영문/숫자/특수문자 포함 6자 이상의 비밀번호를 입력하세요");
 
     private final String type;
     private final String message;

--- a/Member/src/main/java/click/bitbank/api/presentation/member/request/MemberSignupRequest.java
+++ b/Member/src/main/java/click/bitbank/api/presentation/member/request/MemberSignupRequest.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.apache.commons.lang3.StringUtils;
 import click.bitbank.api.infrastructure.exception.status.ExceptionMessage;
 import click.bitbank.api.presentation.shared.request.RequestVerify;
+import java.util.regex.Pattern;
 
 @Getter
 @Builder
@@ -19,8 +20,38 @@ public class MemberSignupRequest implements RequestVerify {
 
     @Override
     public void verify() {
+        verifyLoginId();
+        verifyName();
+        verifyPassword();
+    }
+
+    /**
+     * 로그인 아이디 유효성 검사
+     * 비어있는경우, 문자와 숫자로 구성되어있는지 확인, 8자 이상의 아이디만 가능하도록 검사
+     */
+    private void verifyLoginId() {
         if (StringUtils.isBlank(memberLoginId)) throw new BadRequestException(ExceptionMessage.IsRequiredMemberLoginId.getMessage());
+        if (!StringUtils.isAlphanumeric(memberLoginId)) throw new BadRequestException(ExceptionMessage.IsRequiredAlphaNumericForMemberLoginId.getMessage());
+        if (StringUtils.length(memberLoginId) < 8) throw new BadRequestException(ExceptionMessage.IsRequiredStringLengthForMemberLoginId.getMessage());
+    }
+
+    /**
+     * 회원 이름 유효성 검사
+     * 비어있는경우, 문자로 구성되어 있는지 확인
+     */
+    private void verifyName() {
         if (StringUtils.isBlank(memberName)) throw new BadRequestException(ExceptionMessage.IsRequiredMemberName.getMessage());
+        if (!StringUtils.isAlpha(memberName)) throw new BadRequestException(ExceptionMessage.IsRequiredAlphaForMemberName.getMessage());
+    }
+
+    /**
+     * 비밀번호 유효성 검사
+     * 비어있는지, 영문/숫자/특수문자 포함 6자 이상의 비밀번호인지 검사
+     */
+    private void verifyPassword() {
         if (StringUtils.isBlank(memberPassword)) throw new BadRequestException(ExceptionMessage.IsRequiredMemberPassword.getMessage());
+        // 문자, 숫자, 특수문자 조합의 패턴인지 검사
+        Pattern pattern = Pattern.compile("([a-zA-Z0-9].*[!,@,#,$,%,^,&,*,?,_,~])|([!,@,#,$,%,^,&,*,?,_,~].*[a-zA-Z0-9])");
+        if (!pattern.matcher(memberPassword).find() || StringUtils.length(memberPassword) < 6) throw new BadRequestException(ExceptionMessage.IsRequiredCharNumberSpecialCharactersForMemberPassword.getMessage());
     }
 }


### PR DESCRIPTION
- 이름: 문자로만 구성하도록 조건 추가
- 아이디: 문자 및 숫자로만 구성하도록 하고 아이디 길이는 8이상인지 검사
- 비밀번호: 문자/숫자/특수문자 패턴인지 검사하는 조건 추가